### PR TITLE
Hiding the .constantize model error

### DIFF
--- a/lib/letmein.rb
+++ b/lib/letmein.rb
@@ -137,7 +137,7 @@ module LetMeIn
     end
     
     self.config.models.each do |model|
-      klass = model.constantize rescue next
+      klass = model.constantize
       klass.send :include, LetMeIn::Model
       
       session_model = "#{model.to_s.camelize}Session"


### PR DESCRIPTION
Is there any reason for hiding the error if the code is unable to constantize a LetMeIn model from the config? I spent a while tracking down an error in my code where I had a typo in the User model, but the error appeared to be a LetMeIn error (the UserSession model never get created).

I've attached a short patch that removes the 'rescue next'
